### PR TITLE
[#6] [STUDIO-1287] Temporarily Fix The Version Of The Omniauth Gem

### DIFF
--- a/lib/omniauth/shuttlerock_oauth2/version.rb
+++ b/lib/omniauth/shuttlerock_oauth2/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module OmniAuth
   module ShuttlerockOauth2
-    VERSION = '0.0.3'
+    VERSION = '0.0.4'
   end
 end

--- a/omniauth-shuttlerock-oauth2.gemspec
+++ b/omniauth-shuttlerock-oauth2.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'multi_json'
+  s.add_runtime_dependency 'omniauth', '~> 1.0'
   s.add_runtime_dependency 'omniauth-oauth2'
   s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'rack-test'


### PR DESCRIPTION
[Jira Tech Task](https://shuttlerock.atlassian.net/browse/STUDIO-1287)

No version is specified for the version of omniauth(-oauth2) so it uses the latest version. Omniauth 2.0.0 has now been released but the Devise gem has a broken version check that prevents it being used with Omniauth 2.0.0.

## How to test the PR

Bundle update should result in `bundle info omniauth` returning something like:
```
    * omniauth (1.9.1)
	Summary: A generalized Rack framework for multiple-provider authentication.
	Homepage: https://github.com/omniauth/omniauth
	Path: /Users/srd0045/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/omniauth-1.9.1
```

## Deployment Notes
None
